### PR TITLE
Update admin-menu.php

### DIFF
--- a/src/Config/admin-menu.php
+++ b/src/Config/admin-menu.php
@@ -7,16 +7,19 @@ return [
         'route' => 'admin.dropship.orders.index',
         'sort' => 2,
         'icon-class' => 'dropship-icon',
+        'icon' => 'dropship-icon',
     ], [
         'key' => 'dropship.products',
         'name' => 'dropship::app.admin.layouts.products',
         'route' => 'admin.dropship.products.index',
         'sort' => 1,
+        'icon' => '',
     ], [
         'key' => 'dropship.orders',
         'name' => 'dropship::app.admin.layouts.orders',
         'route' => 'admin.dropship.orders.index',
         'sort' => 2,
+        'icon' => '',
     ]
 ];
 


### PR DESCRIPTION
The menu items processor in bagisto's "core" package expects a collection [via processSubMenuItems($menuItem): Collection] which includes an 'icon' key that can be nullable or otherwise.

If the 'icon' key is absent, it returns an error. 

This is a fix.